### PR TITLE
Use boost:stacktrace for sig_handler for better backtracing

### DIFF
--- a/.devcontainer/Dockerfile.orkaudio.build
+++ b/.devcontainer/Dockerfile.orkaudio.build
@@ -6,7 +6,12 @@ FROM ubuntu:$TAG
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost-dev libboost-all-dev`
+RUN apt-get update && apt-get install -y gnupg && rm -rf /var/lib/apt/lists/* 
+
+RUN . /etc/os-release && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 31F54F3E108EAD31 `
+	&& echo "deb [trusted=yes] http://ppa.launchpad.net/mhier/libboost-latest/ubuntu $UBUNTU_CODENAME main" >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost1.70-dev`
 	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev `
 	libopus-dev libxerces-c3-dev libssl-dev cmake`
 	&& rm -rf /var/lib/apt/lists/* 

--- a/distribution/docker/Dockerfile.orkaudio
+++ b/distribution/docker/Dockerfile.orkaudio
@@ -7,7 +7,12 @@ MAINTAINER Kinshuk B (hi@kinsh.uk)
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost-dev `
+RUN apt-get update && apt-get install -y gnupg && rm -rf /var/lib/apt/lists/* 
+
+RUN . /etc/os-release && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 31F54F3E108EAD31 `
+	&& echo "deb [trusted=yes] http://ppa.launchpad.net/mhier/libboost-latest/ubuntu $UBUNTU_CODENAME main" >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost1.70-dev`
 	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev `
 	libopus-dev libxerces-c3-dev libssl-dev cmake`
 	&& rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
- Use boost:stacktrace for sig_handler for better backtracing
- Linux only Update to boost1.70 as boost:stacktrace is available 1.68+ only