### PR TITLE
Use backward-cpp for backtrace

### DIFF
--- a/.devcontainer/Dockerfile.orkaudio.build
+++ b/.devcontainer/Dockerfile.orkaudio.build
@@ -13,7 +13,7 @@ RUN . /etc/os-release && apt-key adv --keyserver keyserver.ubuntu.com --recv-key
 
 RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost1.70-dev`
 	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev `
-	libopus-dev libxerces-c3-dev libssl-dev cmake`
+	libopus-dev libxerces-c3-dev libssl-dev cmake libdw-dev liblzma-dev libunwind-dev`
 	&& rm -rf /var/lib/apt/lists/* 
 
 #silk
@@ -42,6 +42,11 @@ RUN mkdir -p /opt/bcg729 && chmod 777 /opt/bcg729`
 	&& make `
 	&& make install
 
+#backward-cpp
+RUN mkdir -p /opt/backward-cpp && chmod 777 /opt/backward-cpp`
+	&& git clone --depth 1 https://github.com/bombela/backward-cpp.git /opt/backward-cpp `
+	&& ln -s /opt/backward-cpp/backward.hpp /usr/local/include/backward.hpp
+	
 COPY .devcontainer/build.sh  /entrypoint.sh
 
 #INSERT_HERE

--- a/distribution/docker/Dockerfile.orkaudio
+++ b/distribution/docker/Dockerfile.orkaudio
@@ -14,7 +14,7 @@ RUN . /etc/os-release && apt-key adv --keyserver keyserver.ubuntu.com --recv-key
 
 RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost1.70-dev`
 	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev `
-	libopus-dev libxerces-c3-dev libssl-dev cmake`
+	libopus-dev libxerces-c3-dev libssl-dev cmake libdw-dev liblzma-dev libunwind-dev`
 	&& rm -rf /var/lib/apt/lists/* 
 
 #silk
@@ -43,6 +43,11 @@ RUN mkdir -p /opt/bcg729 && chmod 777 /opt/bcg729`
 	&& make `
 	&& make install
 
+#backward-cpp
+RUN mkdir -p /opt/backward-cpp && chmod 777 /opt/backward-cpp`
+	&& git clone --depth 1 https://github.com/bombela/backward-cpp.git /opt/backward-cpp `
+	&& ln -s /opt/backward-cpp/backward.hpp /usr/local/include/backward.hpp
+
 RUN mkdir -p /opt/oreka && chmod 777 /opt/oreka`
 	&& git clone --depth 1 https://github.com/voiceip/oreka.git /opt/oreka `
 	&& cd /opt/oreka/orkbasecxx `
@@ -62,7 +67,7 @@ MAINTAINER Kinshuk B (hi@kinsh.uk)
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libpcap0.8 libsndfile1 libapr1 libspeex1 liblog4cxx10v5 libace-6.3.3 `
-	libopus0 libxerces-c3.1 libssl1.0.0 && rm -rf /var/lib/apt/lists/* 
+	libopus0 libxerces-c3.1 libssl1.0.0 libdw1 libunwind8 && rm -rf /var/lib/apt/lists/* 
 
 # Mount the image from "builder" stage at `/artifacts` during this run
 RUN --mount=type=bind,source=/,target=/artifacts,from=builder `

--- a/orkaudio/OrkAudio.cpp
+++ b/orkaudio/OrkAudio.cpp
@@ -15,8 +15,9 @@
 #include <iostream>
 #include "stdio.h"
 
-#define BOOST_STACKTRACE_USE_ADDR2LINE
-#include <boost/stacktrace.hpp>
+#define BACKWARD_HAS_DW 1
+#define BACKWARD_HAS_LIBUNWIND 1
+#include "backward.hpp"
 
 #include "MultiThreadedServer.h"
 #include "OrkAudio.h"
@@ -406,19 +407,10 @@ void MainThread()
 	OrkLogManager::Instance()->Shutdown();
 }
 
-void sig_handler(int sig) {
-	// print out all the frames to stderr
-	fprintf(stderr, "Error: signal %d:\n", sig);
-	try {
-    	std::cerr << boost::stacktrace::stacktrace();
-    } catch (...) {}
-  	exit(1);
-}
-
 int main(int argc, char* argv[])
 {
-	signal(SIGSEGV, sig_handler);   // install fatal error handler
-	signal(SIGABRT, sig_handler);   // install abort error handler
+
+	backward::SignalHandling sh; //install fatal error backtrace handler.
 
 	OrkAprSingleton::Initialize();
 

--- a/orkaudio/configure.in
+++ b/orkaudio/configure.in
@@ -19,6 +19,10 @@ if [grep "release 5" /etc/redhat-release]; then
     CXXFLAGS+="-DCENTOS_5"
 fi
 
+AC_LANG_CPLUSPLUS
+AC_PROG_CXX([g++])
+AM_PROG_LIBTOOL
+
 # Check if gcc supports cpp11
 if [echo "main(){}" | $CXX -std=c++11 -xc++ -S -  &>/dev/null] ; then
 	CXXFLAGS+=" -g -O2 -fno-inline-functions -std=c++11 -DSUPPORTS_CPP11 -fPIC"
@@ -27,9 +31,13 @@ else
 	CXXFLAGS+=" -g -O2 -fno-inline-functions"
 fi
 
-AC_LANG_CPLUSPLUS
-AC_PROG_CXX
-AM_PROG_LIBTOOL
+AC_SEARCH_LIBS([dwarf_begin],[dw],[][
+	LDFLAGS+=" -ldw"
+], AC_MSG_ERROR([libdw is not installed.]))
+
+AC_SEARCH_LIBS([unw_backtrace],[unwind],[][
+	LDFLAGS+=" -lunwind"
+], AC_MSG_ERROR([libunwind is not installed.]))
 
 AC_PREFIX_DEFAULT(/usr)
 


### PR DESCRIPTION
This has much better backtracing capability than boost backtrace, which can't show linenumbers for sharedlib's.