### PR TITLE
Release Dockerhub Images from CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build orkaudio Docker
+name: Build Orkaudio Docker
 
 on:
   push:
@@ -26,14 +26,14 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
-      - name: Cache Docker layers ${{ matrix.os-version }}
+      - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.os-version }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.os-version }}-
-      - name: Build Docker Image for ubuntu-${{ matrix.os-version }}
+            ${{ runner.os }}-buildx-
+      - name: Build Docker Image for ubuntu
         uses: docker/build-push-action@v2
         with:
           # using "load: true" forces the docker driver
@@ -46,16 +46,16 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           # build-args: |
-            # TAG=${{ matrix.os-version }}
+            # TAG
       # - name: Compile
       #   run: |
-      #     docker run  -v $(pwd)/oreka-build:/oreka-build -v $(pwd):/oreka-src -i -i localhost:5000/${{ github.repository_owner }}/oreka-${{ matrix.os-version }}:latest bash /entrypoint.sh
-      #     mv ./oreka-build/distribution/orkaudio.deb ./oreka-build/distribution/orkaudio_${{ matrix.os-version }}.deb
+      #     docker run  -v $(pwd)/oreka-build:/oreka-build -v $(pwd):/oreka-src -i -i localhost:5000/${{ github.repository_owner }}/oreka:latest bash /entrypoint.sh
+      #     mv ./oreka-build/distribution/orkaudio.deb ./oreka-build/distribution/orkaudio.deb
       # - name: Upload deb binary
       #   uses: actions/upload-artifact@v2
       #   with:
-      #     name: orkaudio_${{ matrix.os-version }}.deb
-      #     path: ./oreka-build/distribution/orkaudio_${{ matrix.os-version }}.deb
+      #     name: orkaudio.deb
+      #     path: ./oreka-build/distribution/orkaudio.deb
       - name: "Create release"
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,70 @@
+name: Build orkaudio Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:        
+      - v**
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  oreka_docker_job:
+    runs-on: ubuntu-latest
+    name: Build Orkaudio Docker
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Cache Docker layers ${{ matrix.os-version }}
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.os-version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.os-version }}-
+      - name: Build Docker Image for ubuntu-${{ matrix.os-version }}
+        uses: docker/build-push-action@v2
+        with:
+          # using "load: true" forces the docker driver
+          # not necessary here, because we set it before
+          #load: true
+          push: true
+          tags: localhost:5000/${{ github.repository_owner }}/orkaudio:latest
+          context: .
+          file: ./distribution/docker/Dockerfile.orkaudio
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # build-args: |
+            # TAG=${{ matrix.os-version }}
+      # - name: Compile
+      #   run: |
+      #     docker run  -v $(pwd)/oreka-build:/oreka-build -v $(pwd):/oreka-src -i -i localhost:5000/${{ github.repository_owner }}/oreka-${{ matrix.os-version }}:latest bash /entrypoint.sh
+      #     mv ./oreka-build/distribution/orkaudio.deb ./oreka-build/distribution/orkaudio_${{ matrix.os-version }}.deb
+      # - name: Upload deb binary
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: orkaudio_${{ matrix.os-version }}.deb
+      #     path: ./oreka-build/distribution/orkaudio_${{ matrix.os-version }}.deb
+      - name: "Create release"
+        uses: ncipollo/release-action@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          artifacts: "./oreka-build/distribution/*.deb"
+          draft: true
+          allowUpdates: true
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   oreka_docker_job:
     runs-on: ubuntu-latest
-    name: Build Orkaudio Docker
+    name: Build Image
     services:
       registry:
         image: registry:2
@@ -41,7 +41,7 @@ jobs:
           #load: true
           push: true
           tags: localhost:5000/${{ github.repository_owner }}/orkaudio:latest
-          context: .
+          context: ./distribution/docker/
           file: ./distribution/docker/Dockerfile.orkaudio
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,11 +14,7 @@ jobs:
   oreka_docker_job:
     runs-on: ubuntu-latest
     name: Build Image
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +22,21 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: voiceip/orkaudio
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -36,34 +47,14 @@ jobs:
       - name: Build Docker Image for ubuntu
         uses: docker/build-push-action@v2
         with:
-          # using "load: true" forces the docker driver
-          # not necessary here, because we set it before
-          #load: true
-          push: true
-          tags: localhost:5000/${{ github.repository_owner }}/orkaudio:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           context: ./distribution/docker/
           file: ./distribution/docker/Dockerfile.orkaudio
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           # build-args: |
-            # TAG
-      # - name: Compile
-      #   run: |
-      #     docker run  -v $(pwd)/oreka-build:/oreka-build -v $(pwd):/oreka-src -i -i localhost:5000/${{ github.repository_owner }}/oreka:latest bash /entrypoint.sh
-      #     mv ./oreka-build/distribution/orkaudio.deb ./oreka-build/distribution/orkaudio.deb
-      # - name: Upload deb binary
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: orkaudio.deb
-      #     path: ./oreka-build/distribution/orkaudio.deb
-      - name: "Create release"
-        uses: ncipollo/release-action@v1
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          artifacts: "./oreka-build/distribution/*.deb"
-          draft: true
-          allowUpdates: true
-          token: ${{ secrets.GH_TOKEN }}
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/distribution/docker/Dockerfile.orkaudio
+++ b/distribution/docker/Dockerfile.orkaudio
@@ -13,7 +13,7 @@ RUN . /etc/os-release && apt-key adv --keyserver keyserver.ubuntu.com --recv-key
 	&& echo "deb [trusted=yes] http://ppa.launchpad.net/mhier/libboost-latest/ubuntu $UBUNTU_CODENAME main" >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y build-essential libtool automake git tree rpm libboost1.70-dev`
-	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev `
+	libpcap-dev libsndfile1-dev libapr1-dev libspeex-dev liblog4cxx-dev libace-dev libcap-dev `
 	libopus-dev libxerces-c3-dev libssl-dev cmake libdw-dev liblzma-dev libunwind-dev`
 	&& rm -rf /var/lib/apt/lists/* 
 


### PR DESCRIPTION
Dockerhub automated builds have stopped on free accounts, and now requires paid account for that. Hence its much better to manage that via github actions.